### PR TITLE
[FIX] Update org.springframework.ldap version

### DIFF
--- a/spring-security-ldap-4.2.3.RELEASE/pom.xml
+++ b/spring-security-ldap-4.2.3.RELEASE/pom.xml
@@ -72,7 +72,7 @@
             org.springframework.jdbc.core;resolution:=optional;version="[4,5)",
             org.springframework.jdbc.core.support;resolution:=optional;version="[4,5)", 
             org.springframework.util;resolution:=optional;version="[4,5)",
-            org.springframework.ldap*;resolution:=optional;version="[4,5)",
+            org.springframework.ldap*;resolution:=optional;version="[2,3)",
             org.springframework.security.authentication*;version="[4,5)",
             org.springframework.security.core*;version="[4,5)",
             org.springframework.security.crypto.codec;version="[4,5)",


### PR DESCRIPTION
org.springframework.ldap is still in version 2.x (last one is 2.3.1)
